### PR TITLE
Color correction

### DIFF
--- a/lib/src/components/id_preview_component/id_preview_component.dart
+++ b/lib/src/components/id_preview_component/id_preview_component.dart
@@ -31,7 +31,7 @@ class IdPreviewComponent {
     9: "blue",
     10: "green",
     11: "orange",
-    12: "darkgrey",
+    12: "black",
   };
 }
 


### PR DESCRIPTION
I don't know why I thought senior IDs were dark grey, but this fixes that.

For reference, as of now, the colors are:

- Freshmen: blue (#0000ff)
- Sophomores: green (#008000)
- Juniors: orange (#FFA500)
- Seniors: black (#000000)

We may want to look at the color values used by the current ID software before we merge this.